### PR TITLE
Fix rendering of projects.md

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -5,75 +5,15 @@ They had to work on the project for roughly five days and present it to everyone
 Here you can find a list of all resulting projects.
 Please note that some of these repositories lack English documentation. 
 
-<br />
-
-<table>
-  <thead>
-    <tr>
-      <th width="22%">Name</th>
-      <th>Description</th>
-      <th width="30%">Authors</th>
-    </tr>
-  <thead>
-  <tbody>
-    <tr>
-      <td><a href="https://github.com/SvantjeJung/battleship">battleship</a></td>
-      <td>Implementation of the game “battleship” (currently TUI only)</td>
-      <td>Tim&nbsp;Bohne, Svantje&nbsp;Jung, Famke&nbsp;Lamberti</td>
-    </tr>
-    
-    <tr>
-      <td><a href="https://github.com/AndreasSchroeder/rust_game_project">Chicken Fight 3000 Ultimate Tournament</a></td>
-      <td>Action-adventure game about saving the world from evil chicken</td>
-      <td>Fabian&nbsp;Laumeyer, Eduard&nbsp;Rempel, Andreas&nbsp;Schröder, Nguyen&nbsp;Gia&nbsp;Bao&nbsp;Tran</td>
-    </tr>
-    
-    <tr>
-      <td><a href="https://github.com/BenediktSchumacher/Film-O-Mat">Film-O-Mat</a></td>
-      <td>Movie suggestions using data from IMDB</td>
-      <td>Fabian&nbsp;Gutendorf, Anna&nbsp;Sandor, Benedikt&nbsp;Schumacher, Arno&nbsp;Stiefvater</td>
-    </tr>
-    
-    <tr>
-      <td><a href="https://github.com/MMXVII">MMXVII</a></td>
-      <td>Virtual machine and assembler for Knuth's processor architecture MMIX</td>
-      <td>Janina&nbsp;Born, Barbara&nbsp;Butz, Karoline&nbsp;Plum, Tobias&nbsp;Stolzmann</td>
-    </tr>
-    
-    <tr>
-      <td><a href="https://github.com/NiklasPaulRothe/pir-Abschlussprojekt">Pokémon Battle Arena</a></td>
-      <td>Graphical application to experience fights from Pokémon games</td>
-      <td>Artur&nbsp;Kaul, Niklas&nbsp;Rothe, Matthias&nbsp;Thien, Luka&nbsp;Vukusic</td>
-    </tr>
-    
-    <tr>
-      <td><a href="https://github.com/akrimpenfort/pir-radiostation-analyser">radiostation-analyser</a></td>
-      <td>Collect and analyze data about played songs from local radio stations</td>
-      <td>Adrian&nbsp;Krimpenfort, Wilko&nbsp;Müller</td>
-    </tr>    
-    
-    <tr>
-      <td><a href="https://github.com/Christopher22/rust-dtmf">rust-dtmf</a></td>
-      <td>Encoder and decoder for DTMF (≈ old telephone <i>beep</i> sounds)</td>
-      <td>Christopher&nbsp;Gundler, Carmen&nbsp;Meixner</td>
-    </tr>
-    
-    <tr>
-      <td><a href="https://github.com/lmeuser/rust-fortress">rust-fortress</a></td>
-      <td>A Dwarf Fortress like game</td>
-      <td>Nils&nbsp;Affing, Kristin&nbsp;Schmidt</td>
-    </tr>
-        
-    <tr>
-      <td><a href="https://github.com/ArielMant0/RustChess">RustChess</a></td>
-      <td>A 3D chess game using the Vulkan API</td>
-      <td>Franziska&nbsp;Becker, René&nbsp;Warnking</td>
-    </tr>
-        
-    <tr>
-      <td><a href="https://github.com/vab9/pir-project2017">rustle-my-net</a></td>
-      <td>Experimental implementation of a basic neural network from scratch</td>
-      <td>Tom&nbsp;Schneider, Victor&nbsp;Brinkhege, Johann&nbsp;Arndt, Lukas&nbsp;Kalde </td>
-    </tr>
-  </tbody>
-</table>
+Name | Description | Authors
+-----|-------------|--------
+[battleship](https://github.com/SvantjeJung/battleship) | Implementation of the game “battleship” (currently TUI only) | Tim&nbsp;Bohne, Svantje&nbsp;Jung, Famke&nbsp;Lamberti
+[Chicken Fight 3000 Ultimate Tournament](https://github.com/AndreasSchroeder/rust_game_project) | Action-adventure game about saving the world from evil chicken | Fabian&nbsp;Laumeyer, Eduard&nbsp;Rempel, Andreas&nbsp;Schröder, Nguyen&nbsp;Gia&nbsp;Bao&nbsp;Tran
+[Film-O-Mat](https://github.com/BenediktSchumacher/Film-O-Mat) | Movie suggestions using data from IMDB | Fabian&nbsp;Gutendorf, Anna&nbsp;Sandor, Benedikt&nbsp;Schumacher, Arno&nbsp;Stiefvater
+[MMXVII](https://github.com/MMXVII) | Virtual machine and assembler for Knuth's processor architecture MMIX | Janina&nbsp;Born, Barbara&nbsp;Butz, Karoline&nbsp;Plum, Tobias&nbsp;Stolzmann
+[Pokémon Battle Arena](https://github.com/NiklasPaulRothe/pir-Abschlussprojekt) | Graphical application to experience fights from Pokémon games | Artur&nbsp;Kaul, Niklas&nbsp;Rothe, Matthias&nbsp;Thien, Luka&nbsp;Vukusic
+[radiostation-analyser](https://github.com/akrimpenfort/pir-radiostation-analyser) | Collect and analyze data about played songs from local radio stations | Adrian&nbsp;Krimpenfort, Wilko&nbsp;Müller
+[rust-dtmf](https://github.com/Christopher22/rust-dtmf) | Encoder and decoder for DTMF (≈ old telephone *beep* sounds) | Christopher&nbsp;Gundler, Carmen&nbsp;Meixner
+[rust-fortress](https://github.com/lmeuser/rust-fortress) | A Dwarf Fortress like game | Nils&nbsp;Affing, Kristin&nbsp;Schmidt
+[RustChess](https://github.com/ArielMant0/RustChess) | A 3D chess game using the Vulkan API | Franziska&nbsp;Becker, René&nbsp;Warnking
+[rustle-my-net](https://github.com/vab9/pir-project2017) | Experimental implementation of a basic neural network from scratch | Tom&nbsp;Schneider, Victor&nbsp;Brinkhege, Johann&nbsp;Arndt, Lukas&nbsp;Kalde


### PR DESCRIPTION
I'm blaming GitHub for this one. Rewrite the HTML table in GitHub Markdown to fix the broken rendering and get an actual table instead of an HTML block.